### PR TITLE
feat: add boot mode definition

### DIFF
--- a/firmware/baram-qmk-h7s-fw/src/ap/modules/qmk/port/port.h
+++ b/firmware/baram-qmk-h7s-fw/src/ap/modules/qmk/port/port.h
@@ -19,3 +19,4 @@
 #define EECONFIG_USER_KILL_SWITCH_UD  ((void *)((uint32_t)EECONFIG_USER_DATABLOCK + 16)) // 8B
 #define EECONFIG_USER_KKUK            ((void *)((uint32_t)EECONFIG_USER_DATABLOCK + 24)) // 4B
 #define EECONFIG_USER_POLLING_RATE    ((void *)((uint32_t)EECONFIG_USER_DATABLOCK + 28)) // 1B
+#define EECONFIG_USER_BOOT_MODE       ((void *)((uint32_t)EECONFIG_USER_DATABLOCK + 29)) // 1B

--- a/firmware/baram-qmk-h7s-fw/src/hw/driver/usb/boot_mode.h
+++ b/firmware/baram-qmk-h7s-fw/src/hw/driver/usb/boot_mode.h
@@ -1,0 +1,9 @@
+#pragma once
+
+typedef enum
+{
+  BOOT_MODE_USB_HS_8K = 0,
+  BOOT_MODE_USB_HS_4K,
+  BOOT_MODE_USB_FS_1K,
+} boot_mode_t;
+


### PR DESCRIPTION
## Summary
- reserve EEPROM byte for boot mode
- introduce boot mode enum (HS 8K / HS 4K / FS 1K)

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68b60ef0c25883329a50e0ee70a3702a