### PR TITLE
feat: add boot mode manager

### DIFF
--- a/firmware/baram-qmk-h7s-fw/src/ap/modules/qmk/port/port.h
+++ b/firmware/baram-qmk-h7s-fw/src/ap/modules/qmk/port/port.h
@@ -19,3 +19,4 @@
 #define EECONFIG_USER_KILL_SWITCH_UD  ((void *)((uint32_t)EECONFIG_USER_DATABLOCK + 16)) // 8B
 #define EECONFIG_USER_KKUK            ((void *)((uint32_t)EECONFIG_USER_DATABLOCK + 24)) // 4B
 #define EECONFIG_USER_POLLING_RATE    ((void *)((uint32_t)EECONFIG_USER_DATABLOCK + 28)) // 1B
+#define EECONFIG_USER_BOOT_MODE       ((void *)((uint32_t)EECONFIG_USER_DATABLOCK + 29)) // 1B

--- a/firmware/baram-qmk-h7s-fw/src/hw/driver/usb/boot_mode.c
+++ b/firmware/baram-qmk-h7s-fw/src/hw/driver/usb/boot_mode.c
@@ -1,0 +1,72 @@
+#include "boot_mode.h"
+#include "polling_rate.h"
+#include "eeprom.h"
+#include "port.h"
+#include "log.h"
+
+static boot_mode_t current_boot_mode = BOOT_MODE_USB_HS_8K;
+
+void boot_mode_init(void)
+{
+  uint8_t mode;
+  uint32_t addr = (uint32_t)EECONFIG_USER_BOOT_MODE;
+
+  if (eepromReadByte(addr, &mode) == true)
+  {
+    if (mode > BOOT_MODE_USB_FS_1K)
+    {
+      mode = BOOT_MODE_USB_HS_8K;
+      eepromWriteByte(addr, mode);
+    }
+  }
+  else
+  {
+    mode = BOOT_MODE_USB_HS_8K;
+    eepromWriteByte(addr, mode);
+  }
+
+  current_boot_mode = (boot_mode_t)mode;
+}
+
+boot_mode_t boot_mode_get(void)
+{
+  return current_boot_mode;
+}
+
+bool boot_mode_set(boot_mode_t mode)
+{
+  if (mode > BOOT_MODE_USB_FS_1K)
+  {
+    return false;
+  }
+
+  uint32_t addr = (uint32_t)EECONFIG_USER_BOOT_MODE;
+
+  if (eepromWriteByte(addr, (uint8_t)mode) != true)
+  {
+    return false;
+  }
+
+  current_boot_mode = mode;
+  return true;
+}
+
+USBD_SpeedTypeDef boot_mode_apply(void)
+{
+  switch (current_boot_mode)
+  {
+    case BOOT_MODE_USB_HS_4K:
+      polling_rate_set(POLLING_RATE_4K);
+      return USBD_SPEED_HIGH;
+
+    case BOOT_MODE_USB_FS_1K:
+      polling_rate_set(POLLING_RATE_1K);
+      return USBD_SPEED_FULL;
+
+    case BOOT_MODE_USB_HS_8K:
+    default:
+      polling_rate_set(POLLING_RATE_8K);
+      return USBD_SPEED_HIGH;
+  }
+}
+

--- a/firmware/baram-qmk-h7s-fw/src/hw/driver/usb/boot_mode.h
+++ b/firmware/baram-qmk-h7s-fw/src/hw/driver/usb/boot_mode.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <stdbool.h>
+#include "usbd_def.h"
+
+typedef enum
+{
+  BOOT_MODE_USB_HS_8K = 0,
+  BOOT_MODE_USB_HS_4K,
+  BOOT_MODE_USB_FS_1K,
+} boot_mode_t;
+
+void            boot_mode_init(void);
+boot_mode_t     boot_mode_get(void);
+bool            boot_mode_set(boot_mode_t mode);
+USBD_SpeedTypeDef boot_mode_apply(void);
+


### PR DESCRIPTION
## Summary
- reserve EEPROM byte for boot mode and define modes (HS 8K / HS 4K / FS 1K)
- add boot mode manager to load/save mode and apply polling rate and USB speed

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68b60ef0c25883329a50e0ee70a3702a